### PR TITLE
chore: dispatch release after dependency updates

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,6 +14,7 @@ jobs:
       actions: write # Run check workflows
     steps:
       - name: Run dependency update
-        uses: cloud-copilot/action-update-dependencies@1733e6b4858bb0c19a5f7ee496c13c67407cdebc
+        uses: cloud-copilot/action-update-dependencies@4fa36646fdcb3fedd98d1b5d9b9479795fa7cb4f
         with:
           check-workflow: pr-checks.yml
+          post-merge-workflow: release.yml

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
       actions: write # Run check workflows
     steps:
       - name: Run dependency update
-        uses: cloud-copilot/action-update-dependencies@4fa36646fdcb3fedd98d1b5d9b9479795fa7cb4f
+        uses: cloud-copilot/action-update-dependencies@fe48d42724df9c4ed34abf9c0cc97a8da42917f4
         with:
           check-workflow: pr-checks.yml
           post-merge-workflow: release.yml


### PR DESCRIPTION
## Summary
- update the dependency updater action pin to the commit that supports post-merge workflow dispatch
- configure dependency updates to dispatch `release.yml` after the dependency PR is merged

## Context
Merges performed with `github.token` do not trigger downstream `push` workflows, so the release workflow needs to be dispatched explicitly.

## Testing
- Parsed `.github/workflows/update-dependencies.yml` locally with Ruby YAML loader